### PR TITLE
Update repository URL for git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To get started, you can clone the repository and set up your local environment. 
 1. Clone the repository:
 
     ```bash
-    git clone https://github.com/rohan-chandrashekar/5g-network-slicing-simulation.git
+    git clone https://github.com/rohan-chandrashekar/5g-network-slicing.git
     cd 5g-network-slicing-simulation
     ```
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To get started, you can clone the repository and set up your local environment. 
 
     ```bash
     git clone https://github.com/rohan-chandrashekar/5g-network-slicing.git
-    cd 5g-network-slicing-simulation
+    cd 5g-network-slicing
     ```
 
 2. Install the necessary dependencies:


### PR DESCRIPTION
Hi @rohan-chandrashekar!

We have found a small typo in the Readme instructions, as the repository URL is incorrect for the ```git clone``` command. I hope you find this useful 😉 

Thanks for your great work and best regards,

Aitor